### PR TITLE
Add resizing of and appending to Zarr arrays.

### DIFF
--- a/docs/src/tutorial.md
+++ b/docs/src/tutorial.md
@@ -125,7 +125,43 @@ true
 
 ### Resizing and appending
 
-*TODO*
+A Zarr array can be resized, which means that any of its dimensions can be increased or decreased in length. For example:
+
+```jldoctest resize
+julia> using Zarr
+
+julia> z = zzeros(Int32,10000, 10000, chunks=(1000, 1000))
+ZArray{Int32} of size 10000 x 10000
+
+julia> z[:] = 42
+42
+
+julia> resize!(z,20000, 10000)
+
+julia> size(z)
+(20000, 10000)
+```
+
+Note that when an array is resized, the underlying data are not rearranged in any way. If one or more dimensions are shrunk, any chunks falling outside the new array shape will be deleted from the underlying store.
+
+For convenience, `ZArrays` also provide an `append!` method, which can be used to append data to any axis. E.g.:
+
+```jldoctest resize
+julia> a = reshape(1:Int32(10000000),1000, 10000);
+
+julia> z = ZArray(a, chunks=(100, 1000))
+ZArray{Int64} of size 1000 x 10000
+
+julia> size(z)
+(1000, 10000)
+
+julia> append!(z,a)
+
+julia> append!(z,hcat(a,a), dims=1)
+
+julia> size(z)
+(2000, 20000)
+```
 
 ### Compressors
 

--- a/src/Storage/Storage.jl
+++ b/src/Storage/Storage.jl
@@ -60,9 +60,16 @@ Returns the child store of name `name`.
 """
 function getsub end
 
+"""
+    Base.delete!(d::AbstractStore, k::String)
+
+Deletes the given key from the store.
+"""
+
 citostring(i::CartesianIndex) = join(reverse((i - one(i)).I), '.')
 
 Base.getindex(s::AbstractStore, i::CartesianIndex) = s[citostring(i)]
+Base.delete!(s::AbstractStore, i::CartesianIndex) = delete!(s, citostring(i))
 
 maybecopy(x) = copy(x)
 maybecopy(x::String) = x

--- a/src/Storage/dictstore.jl
+++ b/src/Storage/dictstore.jl
@@ -19,6 +19,8 @@ zname(s::DictStore) = s.name
 Base.getindex(d::DictStore,i::String) = get(d.a,i,nothing)
 Base.setindex!(d::DictStore,v,i::String) = d.a[i] = v
 
+Base.delete!(d::DictStore,i::String) = delete!(d.a,i)
+
 subdirs(d::DictStore) = keys(d.subdirs)
 Base.keys(d::DictStore) = keys(d.a)
 newsub(d::DictStore, n) = d.subdirs[n] = DictStore(n)

--- a/src/Storage/directorystore.jl
+++ b/src/Storage/directorystore.jl
@@ -47,5 +47,7 @@ zname(s::DirectoryStore) = splitdir(s.folder)[2]
 
 subdirs(s::DirectoryStore) = filter(i -> isdir(joinpath(s.folder, i)), readdir(s.folder))
 Base.keys(s::DirectoryStore) = filter(i -> isfile(joinpath(s.folder, i)), readdir(s.folder))
+Base.delete!(s::DirectoryStore, k::String) = isfile(joinpath(s.folder, k)) && rm(joinpath(s.folder, k))
+
 
 path(s::DirectoryStore) = s.folder

--- a/src/ZArray.jl
+++ b/src/ZArray.jl
@@ -200,7 +200,7 @@ function readblock!(aout, z::ZArray{<:Any, N}, r::CartesianIndices{N}; readmode=
             # Write data, here one could dispatch on the IndexStyle
             # Of the user-provided array, and then decide on an
             # Indexing style
-            a[i_in_a] .= extractreadinds(aout, linoutinds, i_in_out)
+            copydata!(a,i_in_a, aout,linoutinds, i_in_out)
             writechunk!(maybeinner(a), z, bI + one(bI))
         end
     end
@@ -283,12 +283,13 @@ function writechunk!(a::DenseArray, z::ZArray{<:Any,N}, i::CartesianIndex{N}) wh
     a
 end
 
-function extractreadinds(a,linoutinds,i_in_out)
+function copydata!(a,i_in_a,aout,linoutinds,i_in_out)
     i_in_out2 = linoutinds[i_in_out]
-    a[i_in_out2]
+    a[i_in_a] .= aout[i_in_out2]
 end
+copydata!(a,i_in_a, aout::Number, linoutinds, i_in_out) = a[i_in_a] .= aout
 
-extractreadinds(a::Number, linoutinds, i_in_out) = a
+copydata!(a::AbstractArray{<:Any,N},i_in_a,aout::AbstractArray{<:Any,N},linoutinds,i_in_out) where N = copyto!(a,i_in_a,aout,i_in_out)
 
 """
     zcreate(T, dims...;kwargs)

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -67,7 +67,7 @@ https://zarr.readthedocs.io/en/stable/spec/v2.html#metadata
 """
 struct Metadata{T, N, C}
     zarr_format::Int
-    shape::NTuple{N, Int}
+    shape::Ref{NTuple{N, Int}}
     chunks::NTuple{N, Int}
     dtype::String  # structured data types not yet supported
     compressor::C
@@ -75,6 +75,20 @@ struct Metadata{T, N, C}
     order::Char
     filters::Nothing  # not yet supported
 end
+
+#To make unit tests pass with ref shape
+import Base.==
+function ==(m1::Metadata{T,N,C}, m2::Metadata{T,N,C}) where {T,N,C}
+  m1.zarr_format == m2.zarr_format &&
+  m1.shape[] == m2.shape[] &&
+  m1.chunks == m2.chunks &&
+  m1.dtype == m2.dtype &&
+  m1.compressor == m2.compressor &&
+  m1.fill_value == m2.fill_value &&
+  m1.order == m2.order &&
+  m1.filters == m2.filters
+end
+
 
 "Construct Metadata based on your data"
 function Metadata(A::AbstractArray{T, N}, chunks::NTuple{N, Int};
@@ -130,7 +144,7 @@ end
 function JSON.lower(md::Metadata)
     Dict{String, Any}(
         "zarr_format" => md.zarr_format,
-        "shape" => md.shape |> reverse,
+        "shape" => md.shape[] |> reverse,
         "chunks" => md.chunks |> reverse,
         "dtype" => md.dtype,
         "compressor" => JSON.lower(md.compressor),

--- a/test/storage.jl
+++ b/test/storage.jl
@@ -38,6 +38,9 @@ function test_store_common(ds)
   snew2 = Zarr.getsub(ds,"bar")
   @test Zarr.getattrs(snew2)==Dict("a"=>"b")
   @test snew2["0.0.0"]==data
+  delete!(snew2,"0.0.0")
+  @test !Zarr.isinitialized(snew2,"0.0.0")
+  snew["0.0.0"] = data
 end
 
 @testset "DirectoryStore" begin


### PR DESCRIPTION
This adds the possibility to resize a `ZArray` and to append data to an existing one. I had to make a slight change to the `Metadata` struct. So far everything was immutable, including the `shape` attribute, so I converted this a to reference that can be mutated. The tutorial has been updated as well according to the Zarr intro tutorial. 