### PR TITLE
Refactor Getindex/Setindex

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,22 +3,24 @@ uuid = "0a941bbe-ad1d-11e8-39d9-ab76183a1d99"
 authors = ["Fabian Gans <fgans@bgc-jena.mpg.de>"]
 version = "0.2.0"
 
-[compat]
-julia = "1.1"
-
 [deps]
 AWSCore = "4f1ea46c-232b-54a6-9b17-cc2d0f3e6598"
 AWSS3 = "1c724243-ef5b-51ab-93f4-b0a88ac62a95"
 AWSSDK = "0d499d91-6ae5-5d63-9313-12987b87d5ad"
 Blosc = "a74b3585-a348-5f62-a45c-50e91977d574"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[compat]
+julia = "1.1"
 
 [extras]
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test", "Conda", "PyCall"]

--- a/src/ZArray.jl
+++ b/src/ZArray.jl
@@ -1,5 +1,6 @@
 import JSON
-
+import FillArrays: Fill
+import OffsetArrays: OffsetArray
 getfillval(target::Type{T}, t::String) where {T <: Number} = parse(T, t)
 getfillval(target::Type{T}, t::Union{T,Nothing}) where {T} = t
 
@@ -111,42 +112,13 @@ convert_index2(i, s) = i
 For a given index and blocksize determines which chunks of the Zarray will have to
 be accessed.
 """
-trans_ind(r::AbstractUnitRange, bs) = ((first(r) - 1) ÷ bs):((last(r) - 1) ÷ bs)
-trans_ind(r::Integer, bs) = (r - 1) ÷ bs
+trans_ind(r::AbstractUnitRange, bs) = fld1(first(r),bs):fld1(last(r),bs)
+trans_ind(r::Integer, bs) = fld1(r,bs)
 
-"""
-Most important helper function. Returns two tuples of ranges.
-For a given chunks bI it determines the indices
-to read inside the chunk `i1:i2` as well as the indices to write to in the return
-array `io1:io2`.
-"""
-function inds_in_block(r::CartesianIndices{N}, # Outer Array indices to read
-        bI::CartesianIndex{N}, # Index of the current block to read
-        blockAll::CartesianIndices{N}, # All blocks to read
-        c::NTuple{N, Int}, # Chunks
-        enumI::CartesianIndices{N}, # Idices of all block to read
-        offsfirst::NTuple{N, Int} # Offset of the first block to read
-        ) where {N}
-    sI = size(enumI)
-    map(r.indices, bI.I, blockAll.indices, c, enumI.indices, sI, offsfirst) do iouter,
-            iblock, ablock, chunk, enu, senu, o0
-
-        if iblock == first(ablock)
-            i1 = mod1(first(iouter), chunk)
-            io1 = 1
-        else
-            i1 = 1
-            io1 = (iblock - first(ablock)) * chunk - o0 + 2
-        end
-        if iblock == last(ablock)
-            i2 = mod1(last(iouter), chunk)
-            io2 = length(iouter)
-        else
-            i2 = chunk
-            io2 = (iblock - first(ablock) + 1) * chunk - o0 + 1
-        end
-        i1:i2, io1:io2
-    end
+function boundint(r1, r2)
+    f1, f2  = first(r1), first(r2)
+    l1, l2  = last(r1),last(r2)
+    UnitRange(f1 > f2 ? f1 : f2, l1 < l2 ? l1 : l2)
 end
 
 function getchunkarray(z::ZArray{>:Missing})
@@ -154,62 +126,48 @@ function getchunkarray(z::ZArray{>:Missing})
     inner = zeros(Base.nonmissingtype(eltype(z)), z.metadata.chunks)
     a = SenMissArray(inner,z.metadata.fill_value)
 end
-
-
-
 getchunkarray(z::ZArray) = zeros(eltype(z), z.metadata.chunks)
 
 maybeinner(a::Array) = a
 maybeinner(a::SenMissArray) = a.x
+resetbuffer!(a::Array) = nothing
+resetbuffer!(a::SenMissArray) = fill!(a,missing)
 # Function to read or write from a zarr array. Could be refactored
 # using type system to get rid of the `if readmode` statements.
-function readblock!(aout, z::ZArray{<:Any, N}, r::CartesianIndices{N}; readmode=true) where {N}
-    if !readmode && !z.writeable
-        error("Trying to write to read-only ZArray")
-    end
-    # Determines which chunks are affected
-    blockr = CartesianIndices(map(trans_ind, r.indices, z.metadata.chunks))
-    enumI = CartesianIndices(blockr)
-    # Get the offset of the first index in each dimension
-    offsfirst = map((a, bs) -> mod(first(a) - 1, bs) + 1, r.indices, z.metadata.chunks)
-    # Allocate array of the size of a chunks where uncompressed data can be held
-    a = getchunkarray(z)
-    # Get linear indices from user array. This is a workaround to make something
-    # like z[:] = 1:10 work, because a unit range can not be accessed through
-    # CartesianIndices
-    if !readmode
-          linoutinds = LinearIndices(r)
-    end
-    # Now loop through the chunks
-    for bI in blockr
+function readblock!(aout::AbstractArray{<:Any,N}, z::ZArray{<:Any, N}, r::CartesianIndices{N}; readmode=true) where {N}
 
-        # Get indices to extract and to write to for the current chunk
-        ii = inds_in_block(r, bI, blockr, z.metadata.chunks, enumI, offsfirst)
-        # Extract them as CartesianIndices objects
-        i_in_a = CartesianIndices(map(i -> i[1], ii))
-        i_in_out = CartesianIndices(map(i -> i[2], ii))
-        # Uncompress a chunk
-        if readmode || (isinitialized(z.storage, bI + one(bI)) && (size(i_in_a) != size(a)))
-          readchunk!(maybeinner(a), z, bI + one(bI))
-        end
+  aout = OffsetArray(aout,map(i->first(i)-1,r.indices))
+  if !readmode && !z.writeable
+    error("Trying to write to read-only ZArray")
+  end
+  # Determines which chunks are affected
+  blockr = CartesianIndices(map(trans_ind, r.indices, z.metadata.chunks))
+  # Allocate array of the size of a chunks where uncompressed data can be held
+  a = getchunkarray(z)
+  # Now loop through the chunks
+  foreach(blockr) do bI
 
-        if readmode
-            # Read data
-            copyto!(aout,i_in_out,a,i_in_a)
-        else
-            # Write data, here one could dispatch on the IndexStyle
-            # Of the user-provided array, and then decide on an
-            # Indexing style
-            copydata!(a,i_in_a, aout,linoutinds, i_in_out)
-            writechunk!(maybeinner(a), z, bI + one(bI))
-        end
+    curchunk = OffsetArray(a,map((s,i)->s*(i-1),size(a),Tuple(bI))...)
+
+    inds    = CartesianIndices(map(boundint,r.indices,axes(curchunk)))
+
+    # Uncompress current chunk
+    if !readmode && !(isinitialized(z.storage, bI) && (size(inds) != size(a)))
+      resetbuffer!(a)
+    else
+      readchunk!(maybeinner(a), z, bI)
     end
-    aout
+
+    if readmode
+      # Read data
+      copyto!(aout,inds,curchunk,inds)
+    else
+      copyto!(curchunk,inds,aout,inds)
+      writechunk!(maybeinner(a), z, bI)
+    end
+  end
+  aout
 end
-
-replace_missings!(a,v)=nothing
-replace_missings!(::AbstractArray{>:Missing},::Nothing)=nothing
-replace_missings!(a::AbstractArray{>:Missing},v)=replace!(a,v=>missing)
 
 # Some helper functions to determine the shape of the output array
 gets(x::Tuple) = gets(x...)
@@ -241,16 +199,20 @@ function Base.getindex(z::ZArray{T,1}, ::Colon) where {T}
     reshape(aout, length(aout))
 end
 
-# Method for getting a UnitRange of indices is missing
 
+corshape(ii::CartesianIndices{N}, v::AbstractArray{<:Any,N}) where N = v
+corshape(ii::CartesianIndices, v::AbstractVector{<:Any}) = reshape(v,size(ii))
+corshape(ii::CartesianIndices, v::Number) = Fill(v,size(ii))
+
+# Method for getting a UnitRange of indices is missing
 function Base.setindex!(z::ZArray, v, i...)
     ii = CartesianIndices(map(convert_index, i, size(z)))
-    readblock!(v, z, ii, readmode=false)
+    readblock!(corshape(ii,v), z, ii, readmode=false)
 end
 
 function Base.setindex!(z::ZArray,v,::Colon)
     ii = CartesianIndices(size(z))
-    readblock!(v, z, ii, readmode=false)
+    readblock!(corshape(ii,v), z, ii, readmode=false)
 end
 
 """
@@ -275,6 +237,8 @@ end
 Write the data from the array `a` to the chunk `i` in the ZArray `z`
 """
 function writechunk!(a::DenseArray, z::ZArray{<:Any,N}, i::CartesianIndex{N}) where N
+  z.writeable ||
+    a2 = OffsetArray(a,map((s,i)->s*(i-1)+1,size(a),i.I)...)
     z.writeable || error("ZArray not in write mode")
     length(a) == prod(z.metadata.chunks) || throw(DimensionMismatch("Array size does not equal chunk size"))
     dtemp = UInt8[]
@@ -282,14 +246,6 @@ function writechunk!(a::DenseArray, z::ZArray{<:Any,N}, i::CartesianIndex{N}) wh
     z.storage[i]=dtemp
     a
 end
-
-function copydata!(a,i_in_a,aout,linoutinds,i_in_out)
-    i_in_out2 = linoutinds[i_in_out]
-    a[i_in_a] .= aout[i_in_out2]
-end
-copydata!(a,i_in_a, aout::Number, linoutinds, i_in_out) = a[i_in_a] .= aout
-
-copydata!(a::AbstractArray{<:Any,N},i_in_a,aout::AbstractArray{<:Any,N},linoutinds,i_in_out) where N = copyto!(a,i_in_a,aout,i_in_out)
 
 """
     zcreate(T, dims...;kwargs)

--- a/src/ZArray.jl
+++ b/src/ZArray.jl
@@ -199,7 +199,7 @@ end
 
 corshape(ii::CartesianIndices{N}, v::AbstractArray{<:Any,N}) where N = v
 corshape(ii::CartesianIndices, v::AbstractVector{<:Any}) = reshape(v,size(ii))
-corshape(ii::CartesianIndices, v::Number) = Fill(v,size(ii))
+corshape(ii::CartesianIndices, v) = Fill(v,size(ii))
 
 # Method for getting a UnitRange of indices is missing
 function Base.setindex!(z::ZArray, v, i...)
@@ -245,7 +245,7 @@ function writechunk!(a::DenseArray, z::ZArray{<:Any,N}, i::CartesianIndex{N}) wh
     zcompress(a,dtemp,z.metadata.compressor)
     z.storage[i]=dtemp
   else
-    isinitialized(z.storage,i) || delete!(z.storage,i)
+    isinitialized(z.storage,i) && delete!(z.storage,i)
   end
   a
 end

--- a/src/ZArray.jl
+++ b/src/ZArray.jl
@@ -245,7 +245,7 @@ function writechunk!(a::DenseArray, z::ZArray{<:Any,N}, i::CartesianIndex{N}) wh
     zcompress(a,dtemp,z.metadata.compressor)
     z.storage[i]=dtemp
   else
-    isinitialized(z,i) || delete!(z,i)
+    isinitialized(z.storage,i) || delete!(z,i)
   end
   a
 end

--- a/src/ZArray.jl
+++ b/src/ZArray.jl
@@ -245,7 +245,7 @@ function writechunk!(a::DenseArray, z::ZArray{<:Any,N}, i::CartesianIndex{N}) wh
     zcompress(a,dtemp,z.metadata.compressor)
     z.storage[i]=dtemp
   else
-    isinitialized(z.storage,i) || delete!(z,i)
+    isinitialized(z.storage,i) || delete!(z.storage,i)
   end
   a
 end

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -14,7 +14,7 @@ ASCIIChar(x::UInt8) = reinterpret(ASCIIChar, x)
 UInt8(x::ASCIIChar) = reinterpret(UInt8, x)
 Base.codepoint(x::ASCIIChar) = UInt8(x)
 Base.show(io::IO, x::ASCIIChar) = print(io, Char(x))
-Base.zero(ASCIIChar) = ASCIIChar(Base.zero(UInt8))
+Base.zero(::ASCIIChar) = ASCIIChar(Base.zero(UInt8))
 
 
 typestr(t::Type) = string('<', 'V', sizeof(t))

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -14,7 +14,7 @@ ASCIIChar(x::UInt8) = reinterpret(ASCIIChar, x)
 UInt8(x::ASCIIChar) = reinterpret(UInt8, x)
 Base.codepoint(x::ASCIIChar) = UInt8(x)
 Base.show(io::IO, x::ASCIIChar) = print(io, Char(x))
-Base.zero(::ASCIIChar) = ASCIIChar(Base.zero(UInt8))
+Base.zero(::Union{ASCIIChar,Type{ASCIIChar}}) = ASCIIChar(Base.zero(UInt8))
 
 
 typestr(t::Type) = string('<', 'V', sizeof(t))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -136,6 +136,20 @@ end
   @test a[4,4] == 0
   @test a[5:6,5:6] == [1 0; 0 0]
   @test a[9:10,9:10] == fill(2,2,2)
+  # Now with FillValue
+  amiss = zzeros(Int64, 10,10,chunks=(5,2), fill_value=-1)
+  amiss[:,1] = 1:10
+  amiss[:,2] = missing
+  amiss[1:3,4] = [1,missing,3]
+  amiss[1,10] = 5
+  amiss[1:5,9:10] = missing
+
+  @test amiss[:,1] == 1:10
+  @test all(ismissing,amiss[:,2])
+  @test all(i->isequal(i...),zip(amiss[1:3,4],[1,missing,3]))
+  # Test that chunk containing only missings is not initialized
+  @test !Zarr.isinitialized(amiss.storage,Zarr.citostring(CartesianIndex((1,5))))
+
 end
 
 @testset "resize" begin


### PR DESCRIPTION
This is a small rewrite of the machinery that handles IO of rectangular blocks of data. The code should be simpler and more readable through this change at the cost of introducing `OffsetArrays` as a dependency. 