### PR TITLE
add ZArray to ZGroup arrays dict in zcreate

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Zarr"
 uuid = "0a941bbe-ad1d-11e8-39d9-ab76183a1d99"
 authors = ["Fabian Gans <fgans@bgc-jena.mpg.de>"]
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
 AWSCore = "4f1ea46c-232b-54a6-9b17-cc2d0f3e6598"

--- a/src/ZGroup.jl
+++ b/src/ZGroup.jl
@@ -96,5 +96,7 @@ zgroup(g::ZGroup, name; attrs=Dict()) = g.groups[name] = zgroup(newsub(g.storage
 "Create a new subarray of the group g"
 function zcreate(::Type{T},g::ZGroup, name::String, addargs...; kwargs...) where T
   newstore = newsub(g.storage,name)
-  zcreate(T, newstore, addargs...; kwargs...)
+  z = zcreate(T, newstore, addargs...; kwargs...)
+  g.arrays[name] = z
+  return z
 end


### PR DESCRIPTION
I created a group with a few arrays like so:

```julia

using Zarr

nrow = 1300
ncol = 1200
cellsize = 250.0
zpath = "data/chloride.zarr"

"Prepare an empty Zarr group with populated axes"
function prepare_zarr(path, nrow, ncol, cellsize)
    # only use compression on the data, not on the axes
    compressor = Zarr.BloscCompressor()
    # remove possible old zarr
    rm(path, force = true, recursive = true)
    store = DirectoryStore(path)
    group = zgroup(store)
    zchloride = Zarr.zcreate(
        Float64,
        group,
        "chloride",
        nrow,
        ncol;
        chunks = (100, 100),
        compressor = compressor,
    )
    zx = Zarr.zcreate(Float64, group, "x", ncol; compressor = Zarr.NoCompressor())
    zy = Zarr.zcreate(Float64, group, "y", nrow; compressor = Zarr.NoCompressor())
    zx[:] = range(cellsize / 2, step = cellsize, length = ncol)
    zy[:] = range(625000 - cellsize / 2, step = -250.0, length = nrow)
    return group
end

group = prepare_zarr(zpath, nrow, ncol, cellsize)
```
 But was surprised to find that I could not retrieve the arrays from the group with `group["chloride"]`. This was because `g.arrays` (used by `getindex`) was empty. This commit populates `g.arrays` during `zcreate`.