### PR TITLE
ignore subfolders that are not Zarr objects or arrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Zarr"
 uuid = "0a941bbe-ad1d-11e8-39d9-ab76183a1d99"
 authors = ["Fabian Gans <fgans@bgc-jena.mpg.de>"]
-version = "0.6.1"
+version = "0.6.2"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"


### PR DESCRIPTION
In the python Zarr implementation subfolders that don't contain a .zarray or .zgroup identifier are ignored, while we have thrown an error so far. This PR changes the behavior to mimic the python one