### PR TITLE
Rewrite the storage interface

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,11 +39,15 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
         env:
-          PYTHON: 
+          PYTHON:
       - uses: julia-actions/julia-runtest@v1
         env:
-          PYTHON: 
+          PYTHON:
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:
           file: lcov.info
+      - uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./lcov.info

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Zarr"
 uuid = "0a941bbe-ad1d-11e8-39d9-ab76183a1d99"
 authors = ["Fabian Gans <fgans@bgc-jena.mpg.de>"]
-version = "0.6.1"
+version = "0.6.2"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,6 @@ uuid = "0a941bbe-ad1d-11e8-39d9-ab76183a1d99"
 authors = ["Fabian Gans <fgans@bgc-jena.mpg.de>"]
 version = "0.7.0"
 
-
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"
 Blosc = "a74b3585-a348-5f62-a45c-50e91977d574"
@@ -17,7 +16,7 @@ OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [compat]
-AWS = "1.25"
+AWS = "1.25 - 1.61"
 Blosc = "0.5, 0.6, 0.7"
 CodecZlib = "0.6, 0.7"
 DataStructures = "0.17, 0.18"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Zarr"
 uuid = "0a941bbe-ad1d-11e8-39d9-ab76183a1d99"
 authors = ["Fabian Gans <fgans@bgc-jena.mpg.de>"]
-version = "0.6.2"
+version = "0.7.0"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"

--- a/src/Storage/Storage.jl
+++ b/src/Storage/Storage.jl
@@ -11,12 +11,6 @@ This function shall return the size of all data files in a store.
 """
 function storagesize end
 
-"""
-    zname(d::AbstractStore)
-
-Returns the name of the current variable.
-"""
-function zname end
 
 """
     Base.getindex(d::AbstractStore,i::String)
@@ -33,32 +27,19 @@ Writes the values in v to the given store and key.
 Base.setindex!(d::AbstractStore,v,i::AbstractString) = error("setindex not implemented for store $(typeof(d))")
 
 """
-    subdirs(d::AbstractStore)
+    subdirs(d::AbstractStore, p)
 
-Returns a list of keys for children stores in the given store.
+Returns a list of keys for children stores in the given store at path p.
 """
 function subdirs end
 
 """
-    Base.keys(d::AbstractStore)
+    subkeys(d::AbstractStore, p)
 
 Returns the keys of files in the given store.
 """
-Base.keys(d::AbstractStore) = error("keys function not implemented for store $(typeof(d))")
+function subkeys end 
 
-"""
-    newsub(d::AbstractStore, name::String)
-
-Create a new Store as a child of the given store `d` with given `name`. Returns the new created substore.
-"""
-function newsub end
-
-"""
-    getsub(d::AbstractStore, name::String)
-
-Returns the child store of name `name`.
-"""
-function getsub end
 
 """
     Base.delete!(d::AbstractStore, k::String)
@@ -67,47 +48,53 @@ Deletes the given key from the store.
 """
 
 citostring(i::CartesianIndex) = join(reverse((i - oneunit(i)).I), '.')
+_concatpath(p,s) = rstrip(p,'/') * '/' * s
 
-Base.getindex(s::AbstractStore, i::CartesianIndex) = s[citostring(i)]
-Base.delete!(s::AbstractStore, i::CartesianIndex) = delete!(s, citostring(i))
+Base.getindex(s::AbstractStore, p, i::CartesianIndex) = s[p, citostring(i)]
+Base.getindex(s::AbstractStore, p, i) = s[_concatpath(p,i)]
+Base.delete!(s::AbstractStore, p, i::CartesianIndex) = delete!(s, p, citostring(i))
+Base.delete!(s::AbstractStore, p, i) = delete!(s, _concatpath(p,i))
 Base.haskey(s::AbstractStore, k) = isinitialized(s,k)
+Base.setindex!(s::AbstractStore,v,p,i) = setindex!(s,v,_concatpath(p,i))
+Base.setindex!(s::AbstractStore,v,p,i::CartesianIndex) = s[p, citostring(i)]=v
+
 
 maybecopy(x) = copy(x)
 maybecopy(x::String) = x
 
-function getattrs(s::AbstractStore)
-  atts = s[".zattrs"]
+
+function getattrs(s::AbstractStore, p)
+  atts = s[p,".zattrs"]
   if atts === nothing
     Dict()
   else
     JSON.parse(replace(String(maybecopy(atts)),": NaN,"=>": \"NaN\","))
   end
 end
-function writeattrs(s::AbstractStore, att::Dict)
+function writeattrs(s::AbstractStore, p, att::Dict)
   b = IOBuffer()
   JSON.print(b,att)
-  s[".zattrs"] = take!(b)
+  s[p,".zattrs"] = take!(b)
   att
 end
 
-is_zgroup(s::AbstractStore) = isinitialized(s,".zgroup")
-is_zarray(s::AbstractStore) = isinitialized(s,".zarray")
+is_zgroup(s::AbstractStore, p) = isinitialized(s,rstrip(p,'/') * "/.zgroup")
+is_zarray(s::AbstractStore, p) = isinitialized(s,rstrip(p,'/') * "/.zarray")
 
-isinitialized(s::AbstractStore, i::CartesianIndex)=isinitialized(s,citostring(i))
-
+isinitialized(s::AbstractStore, p, i::CartesianIndex)=isinitialized(s,p,citostring(i))
+isinitialized(s::AbstractStore, p, i) = isinitialized(s,_concatpath(p,i))
 isinitialized(s::AbstractStore, i) = s[i] !== nothing
 
-getmetadata(s::AbstractStore) = Metadata(String(s[".zarray"]))
-function writemetadata(s::AbstractStore, m::Metadata)
+getmetadata(s::AbstractStore, p) = Metadata(String(s[p,".zarray"]))
+function writemetadata(s::AbstractStore, p, m::Metadata)
   met = IOBuffer()
   JSON.print(met,m)
-  s[".zarray"] = take!(met)
+  s[p,".zarray"] = take!(met)
   m
 end
 
-Base.setindex!(s::AbstractStore,v,i::CartesianIndex) = s[citostring(i)]=v
 
-Base.isempty(s::AbstractStore) = isempty(keys(s)) && isempty(subdirs(s))
+isemptysub(s::AbstractStore, p) = isempty(subkeys(s,p)) && isempty(subdirs(s,p))
 
 #Here different storage backends can register regexes that are checked against
 #during auto-check of storage format when doing zopen

--- a/src/Storage/Storage.jl
+++ b/src/Storage/Storage.jl
@@ -48,7 +48,7 @@ Deletes the given key from the store.
 """
 
 citostring(i::CartesianIndex) = join(reverse((i - oneunit(i)).I), '.')
-_concatpath(p,s) = rstrip(p,'/') * '/' * s
+_concatpath(p,s) = isempty(p) ? s : rstrip(p,'/') * '/' * s
 
 Base.getindex(s::AbstractStore, p, i::CartesianIndex) = s[p, citostring(i)]
 Base.getindex(s::AbstractStore, p, i) = s[_concatpath(p,i)]
@@ -78,14 +78,14 @@ function writeattrs(s::AbstractStore, p, att::Dict)
   att
 end
 
-is_zgroup(s::AbstractStore, p) = isinitialized(s,rstrip(p,'/') * "/.zgroup")
-is_zarray(s::AbstractStore, p) = isinitialized(s,rstrip(p,'/') * "/.zarray")
+is_zgroup(s::AbstractStore, p) = isinitialized(s,_concatpath(p,".zgroup"))
+is_zarray(s::AbstractStore, p) = isinitialized(s,_concatpath(p,".zarray"))
 
 isinitialized(s::AbstractStore, p, i::CartesianIndex)=isinitialized(s,p,citostring(i))
 isinitialized(s::AbstractStore, p, i) = isinitialized(s,_concatpath(p,i))
 isinitialized(s::AbstractStore, i) = s[i] !== nothing
 
-getmetadata(s::AbstractStore, p) = Metadata(String(s[p,".zarray"]))
+getmetadata(s::AbstractStore, p) = Metadata(String(maybecopy(s[p,".zarray"])))
 function writemetadata(s::AbstractStore, p, m::Metadata)
   met = IOBuffer()
   JSON.print(met,m)

--- a/src/Storage/consolidated.jl
+++ b/src/Storage/consolidated.jl
@@ -5,14 +5,15 @@ data will be read from the dictionary instead.
 """
 struct ConsolidatedStore{P} <: AbstractStore
   parent::P
-  cons::Dict{String}
+  path::String
+  cons::DictStore
 end
-function ConsolidatedStore(s::AbstractStore)
-  d = s[".zmetadata"]
+function ConsolidatedStore(s::AbstractStore, p)
+  d = s[p, ".zmetadata"]
   if d === nothing
     throw(ArgumentError("Could not find consolidated metadata for store $s"))
   end
-  ConsolidatedStore(s,JSON.parse(String(Zarr.maybecopy(d)))["metadata"])
+  ConsolidatedStore(s,p,DictStore(JSON.parse(String(Zarr.maybecopy(d)))["metadata"]))
 end
 
 function Base.show(io::IO,d::ConsolidatedStore)
@@ -21,56 +22,38 @@ function Base.show(io::IO,d::ConsolidatedStore)
     print(io, "Consolidated ", String(take!(b)))
 end
 
-storagesize(d::ConsolidatedStore) = storagesize(d.parent)
-zname(s::ConsolidatedStore) = zname(s.parent)
-Base.getindex(d::ConsolidatedStore,i::String) = d.parent[i]
-getmetadata(d::ConsolidatedStore) = Metadata(d.cons[".zarray"])
-getattrs(d::ConsolidatedStore) = get(d.cons,".zattrs", Dict{String,Any}())
-is_zarray(d::ConsolidatedStore) = haskey(d.cons,".zarray")
-is_zgroup(d::ConsolidatedStore) = haskey(d.cons,".zgroup")
+storagesize(d::ConsolidatedStore) = storagesize(d.parent,p)
+function Base.getindex(d::ConsolidatedStore,i::String) 
+  r = d.cons[i]
+  if r === nothing
+    d.parent[i]
+  end
+end
+# getmetadata(d::ConsolidatedStore,p) = Metadata(d.cons[".zarray"])
+# getattrs(d::ConsolidatedStore) = get(d.cons,".zattrs", Dict{String,Any}())
+is_zarray(d::ConsolidatedStore,p) = is_zarray(d.cons,p)
+is_zgroup(d::ConsolidatedStore,p) = is_zgroup(d.cons,p)
 check_consolidated_write(i::String) = split(i,'/')[end] in (".zattrs",".zarray",".zgroup") &&
     throw(ArgumentError("Can not modify consolidated metadata, please re-open the dataset with `consolidated=false`"))
 function Base.setindex!(d::ConsolidatedStore,v,i::String)
   #Here we check that we don't overwrite consolidated information
   check_consolidated_write(i)
-  d.parent.a[i] = v
+  d.parent[i] = v
 end
 function Base.delete!(d::ConsolidatedStore,i::String)
   check_consolidated_write(i)
-  delete!(d.a,i)
+  delete!(d.parent,i)
 end
-function subdirs(d::ConsolidatedStore)
-  o = Set{String}()
-  foreach(collect(keys(d.cons))) do k
-    tr = split(k,'/')
-    length(tr) > 1 && push!(o,first(tr))
-  end
-  collect(o)
-end
-Base.keys(d::ConsolidatedStore) = keys(d.parent)
-newsub(d::ConsolidatedStore, n) = newsub(d.parent, n)
-function getsub(d::ConsolidatedStore, n)
-    newd = Dict{String,Any}()
-    for (k,v) in d.cons
-        s = split(k,'/')
-        if s[1] == n
-            newd[join(s[2:end],'/')] = v
-        end
-    end
-    ConsolidatedStore(getsub(d.parent, n), newd)
-end
-path(d::ConsolidatedStore) = path(d.parent)
 
 function consolidate_metadata(s::AbstractStore,d,prefix)
   for k in (".zattrs",".zarray",".zgroup")
-    v = s[k]
+    v = s[prefix,k]
     if v !== nothing
       d[string(prefix,k)] = JSON.parse(replace(String(Zarr.maybecopy(v)),": NaN,"=>": \"NaN\","))
     end
   end
   foreach(subdirs(s)) do subname
-    ssub = getsub(s,subname)
-    consolidate_metadata(ssub,d,string(prefix,subname,"/"))
+    consolidate_metadata(s,d,string(prefix,subname,"/"))
   end
   d
 end

--- a/src/Storage/consolidated.jl
+++ b/src/Storage/consolidated.jl
@@ -22,7 +22,7 @@ function Base.show(io::IO,d::ConsolidatedStore)
     print(io, "Consolidated ", String(take!(b)))
 end
 
-storagesize(d::ConsolidatedStore) = storagesize(d.parent,p)
+storagesize(d::ConsolidatedStore,p) = storagesize(d.parent,p)
 function Base.getindex(d::ConsolidatedStore,i::String) 
     d.parent[i]
 end
@@ -46,9 +46,7 @@ function subdirs(d::ConsolidatedStore,p)
 end
 
 function subkeys(d::ConsolidatedStore,p) 
-  p2 = _unconcpath(d,p)
-  d2 = _pdict(d,p2)
-  _searchsubdict(d2,p,(sp,lp)->length(sp) == lp+1)
+  subkeys(d.parent,p)
 end
 
 

--- a/src/Storage/consolidated.jl
+++ b/src/Storage/consolidated.jl
@@ -6,14 +6,14 @@ data will be read from the dictionary instead.
 struct ConsolidatedStore{P} <: AbstractStore
   parent::P
   path::String
-  cons::DictStore
+  cons::Dict{String,Any}
 end
 function ConsolidatedStore(s::AbstractStore, p)
   d = s[p, ".zmetadata"]
   if d === nothing
     throw(ArgumentError("Could not find consolidated metadata for store $s"))
   end
-  ConsolidatedStore(s,p,DictStore(JSON.parse(String(Zarr.maybecopy(d)))["metadata"]))
+  ConsolidatedStore(s,p,JSON.parse(String(Zarr.maybecopy(d)))["metadata"])
 end
 
 function Base.show(io::IO,d::ConsolidatedStore)
@@ -24,17 +24,35 @@ end
 
 storagesize(d::ConsolidatedStore) = storagesize(d.parent,p)
 function Base.getindex(d::ConsolidatedStore,i::String) 
-  r = d.cons[i]
-  if r === nothing
     d.parent[i]
-  end
 end
-# getmetadata(d::ConsolidatedStore,p) = Metadata(d.cons[".zarray"])
-# getattrs(d::ConsolidatedStore) = get(d.cons,".zattrs", Dict{String,Any}())
-is_zarray(d::ConsolidatedStore,p) = is_zarray(d.cons,p)
-is_zgroup(d::ConsolidatedStore,p) = is_zgroup(d.cons,p)
+getmetadata(d::ConsolidatedStore,p) = Metadata(d.cons[_unconcpath(d,p,".zarray")])
+getattrs(d::ConsolidatedStore, p) = get(d.cons,_unconcpath(d,p,".zattrs"), Dict{String,Any}())
+function _unconcpath(d,p)
+  startswith(p,d.path) || error("Requested key is not in consolidated path")
+  lstrip(replace(p,d.path=>"", count=1),'/')
+end
+_unconcpath(d,p,s) = _concatpath(_unconcpath(d,p),s)
+is_zarray(d::ConsolidatedStore,p) = haskey(d.cons,_unconcpath(d,p,".zarray"))
+is_zgroup(d::ConsolidatedStore,p) = haskey(d.cons,_unconcpath(d,p,".zgroup"))
 check_consolidated_write(i::String) = split(i,'/')[end] in (".zattrs",".zarray",".zgroup") &&
     throw(ArgumentError("Can not modify consolidated metadata, please re-open the dataset with `consolidated=false`"))
+
+_pdict(d::ConsolidatedStore,p) = filter(((k,v),)->startswith(k,p),d.cons)
+function subdirs(d::ConsolidatedStore,p) 
+  p2 = _unconcpath(d,p)
+  d2 = _pdict(d,p2)
+  _searchsubdict(d2,p,(sp,lp)->length(sp) > lp+1)
+end
+
+function subkeys(d::ConsolidatedStore,p) 
+  p2 = _unconcpath(d,p)
+  d2 = _pdict(d,p2)
+  _searchsubdict(d2,p,(sp,lp)->length(sp) == lp+1)
+end
+
+
+
 function Base.setindex!(d::ConsolidatedStore,v,i::String)
   #Here we check that we don't overwrite consolidated information
   check_consolidated_write(i)
@@ -45,24 +63,25 @@ function Base.delete!(d::ConsolidatedStore,i::String)
   delete!(d.parent,i)
 end
 
+
 function consolidate_metadata(s::AbstractStore,d,prefix)
   for k in (".zattrs",".zarray",".zgroup")
     v = s[prefix,k]
     if v !== nothing
-      d[string(prefix,k)] = JSON.parse(replace(String(Zarr.maybecopy(v)),": NaN,"=>": \"NaN\","))
+      d[_concatpath(prefix,k)] = JSON.parse(String(copy(v)))
     end
   end
-  foreach(subdirs(s)) do subname
+  foreach(subdirs(s,prefix)) do subname
     consolidate_metadata(s,d,string(prefix,subname,"/"))
   end
   d
 end
-function consolidate_metadata(s::AbstractStore)
-  d = consolidate_metadata(s,Dict{String,Any}(),"")
+function consolidate_metadata(s::AbstractStore,p)
+  d = consolidate_metadata(s,Dict{String,Any}(),p)
   buf = IOBuffer()
   JSON.print(buf,Dict("metadata"=>d),4)
-  s[".zmetadata"] = take!(buf)
-  ConsolidatedStore(s)
+  s[p,".zmetadata"] = take!(buf)
+  ConsolidatedStore(s,p,d)
 end
 
-consolidate_metadata(s) = consolidate_metadata(zopen(s))
+consolidate_metadata(s) = consolidate_metadata(zopen(s,"w"))

--- a/src/Storage/dictstore.jl
+++ b/src/Storage/dictstore.jl
@@ -5,9 +5,9 @@ end
 DictStore() = DictStore(Dict{String,Vector{UInt8}}())
 
 Base.show(io::IO,d::DictStore) = print(io,"Dictionary Storage")
-_pdict(d,p) = filter(((k,v),)->startswith(k,p),d.a)
+_pdict(d::DictStore,p) = filter(((k,v),)->startswith(k,p),d.a)
 function storagesize(d::DictStore,p) 
-  sum(i->i[1] ∉ (".zattrs",".zarray") ? sizeof(i[2]) : zero(sizeof(i[2])), _pdict(d,p))
+  sum(i->last(split(i[1],'/')) ∉ (".zattrs",".zarray") ? sizeof(i[2]) : zero(sizeof(i[2])), _pdict(d,p))
 end
 
 function Base.getindex(d::DictStore,i::AbstractString) 
@@ -20,29 +20,32 @@ Base.delete!(d::DictStore, i::AbstractString) = delete!(d.a,i)
 
 function subdirs(d::DictStore,p) 
   d2 = _pdict(d,p)
+  _searchsubdict(d2,p,(sp,lp)->length(sp) > lp+1)
+end
+
+function subkeys(d::DictStore,p) 
+  d2 = _pdict(d,p)
+  _searchsubdict(d2,p,(sp,lp)->length(sp) == lp+1)
+end
+
+function _searchsubdict(d2,p,condition)
   o = Set{String}()
-  lp = length(split(rstrip(p,'/'),'/'))
-  for (k,_) in d2
+  pspl = split(rstrip(p,'/'),'/')
+  lp = if length(pspl) == 1 && isempty(pspl[1])
+    0
+  else
+    length(pspl)
+  end
+  for k in keys(d2)
     sp = split(k,'/')
-    if length(sp) > lp+1
+    if condition(sp,lp)
       push!(o,sp[lp+1])
     end
   end
   collect(o)
 end
 
-function subkeys(d::DictStore,p) 
-  d2 = _pdict(d,p)
-  o = Set{String}()
-  lp = length(split(rstrip(p,'/'),'/'))
-  for (k,_) in d2
-    sp = split(k,'/')
-    if length(sp) == lp+1
-      push!(o,sp[lp+1])
-    end
-  end
-  collect(o)
-end
+
 #getsub(d::DictStore, p, n) = _substore(d,p).subdirs[n]
 
 #path(d::DictStore) = ""

--- a/src/Storage/directorystore.jl
+++ b/src/Storage/directorystore.jl
@@ -32,22 +32,12 @@ function Base.setindex!(d::DirectoryStore,v,i::String)
   v
 end
 
-getsub(s::DirectoryStore, d::String) = DirectoryStore(joinpath(s.folder,d))
 
-function newsub(s::DirectoryStore, d::String)
-  p = mkpath(joinpath(s.folder,d))
-  DirectoryStore(p)
-end
-
-storagesize(d::DirectoryStore) = sum(filter(i->i ∉ (".zattrs",".zarray"),readdir(d.folder))) do f
+storagesize(d::DirectoryStore,p) = sum(filter(i->i ∉ (".zattrs",".zarray"),readdir(d.folder))) do f
   filesize(joinpath(d.folder,f))
 end
 
-zname(s::DirectoryStore) = splitdir(s.folder)[2]
-
-subdirs(s::DirectoryStore) = filter(i -> isdir(joinpath(s.folder, i)), readdir(s.folder))
-Base.keys(s::DirectoryStore) = filter(i -> isfile(joinpath(s.folder, i)), readdir(s.folder))
+subdirs(s::DirectoryStore,p) = filter(i -> isdir(joinpath(s.folder,p, i)), readdir(joinpath(s.folder,p)))
+subkeys(s::DirectoryStore,p) = filter(i -> isfile(joinpath(s.folder,p, i)), readdir(joinpath(s.folder,p)))
 Base.delete!(s::DirectoryStore, k::String) = isfile(joinpath(s.folder, k)) && rm(joinpath(s.folder, k))
 
-
-path(s::DirectoryStore) = s.folder

--- a/src/Storage/directorystore.jl
+++ b/src/Storage/directorystore.jl
@@ -27,17 +27,34 @@ function Base.getindex(d::DirectoryStore, i::String)
 end
 
 function Base.setindex!(d::DirectoryStore,v,i::String)
-  fname=joinpath(d.folder,i)
+  fname=d.folder * "/" * i
+  folder = dirname(fname)
+  isdir(folder) || mkpath(folder)
   write(fname,v)
   v
 end
 
 
-storagesize(d::DirectoryStore,p) = sum(filter(i->i ∉ (".zattrs",".zarray"),readdir(d.folder))) do f
-  filesize(joinpath(d.folder,f))
+storagesize(d::DirectoryStore,p) = sum(filter(i->i ∉ (".zattrs",".zarray"),readdir(d.folder * "/" * p))) do f
+  fname = d.folder * "/" * p * "/" * f
+  filesize(fname)
 end
 
-subdirs(s::DirectoryStore,p) = filter(i -> isdir(joinpath(s.folder,p, i)), readdir(joinpath(s.folder,p)))
-subkeys(s::DirectoryStore,p) = filter(i -> isfile(joinpath(s.folder,p, i)), readdir(joinpath(s.folder,p)))
+function subdirs(s::DirectoryStore,p) 
+  pbase = joinpath(s.folder,p)
+  if !isdir(pbase) 
+    return String[]
+  else
+    return filter(i -> isdir(joinpath(s.folder,p, i)), readdir(pbase))
+  end
+end
+function subkeys(s::DirectoryStore,p) 
+  pbase = joinpath(s.folder,p)
+  if !isdir(pbase) 
+    return String[]
+  else
+    return filter(i -> isfile(joinpath(s.folder,p, i)), readdir(pbase))
+  end
+end
 Base.delete!(s::DirectoryStore, k::String) = isfile(joinpath(s.folder, k)) && rm(joinpath(s.folder, k))
 

--- a/src/Storage/http.jl
+++ b/src/Storage/http.jl
@@ -13,6 +13,7 @@ struct HTTPStore <: AbstractStore
 end
 
 function Base.getindex(s::HTTPStore, k::String)
+  @show string(s.url,"/",k)
 r = HTTP.request("GET",string(s.url,"/",k),status_exception = false)
 if r.status >= 300
     if r.status == 404
@@ -27,7 +28,7 @@ end
 
 push!(storageregexlist,r"^https://"=>HTTPStore)
 push!(storageregexlist,r"^http://"=>HTTPStore)
-storefromstring(::Type{<:HTTPStore}, s) = ConsolidatedStore(HTTPStore(s)),""
+storefromstring(::Type{<:HTTPStore}, s) = ConsolidatedStore(HTTPStore(s),""),""
 ## This is a server implementation for Zarr datasets
 
 
@@ -54,4 +55,4 @@ function zarr_req_handler(s::AbstractStore, p)
 end
 
 
-HTTP.serve(s::AbstractStore, args...; kwargs...) = HTTP.serve(zarr_req_handler(s),args...;kwargs...)
+HTTP.serve(s::AbstractStore, p, args...; kwargs...) = HTTP.serve(zarr_req_handler(s,p),args...;kwargs...)

--- a/src/Storage/http.jl
+++ b/src/Storage/http.jl
@@ -13,7 +13,6 @@ struct HTTPStore <: AbstractStore
 end
 
 function Base.getindex(s::HTTPStore, k::String)
-  @show string(s.url,"/",k)
 r = HTTP.request("GET",string(s.url,"/",k),status_exception = false)
 if r.status >= 300
     if r.status == 404

--- a/src/ZArray.jl
+++ b/src/ZArray.jl
@@ -26,6 +26,7 @@ Base.IndexStyle(::Type{<:SenMissArray})=Base.IndexLinear()
 struct ZArray{T, N, C<:Compressor, S<:AbstractStore} <: AbstractDiskArray{T,N}
     metadata::Metadata{T, N, C}
     storage::S
+    path::String
     attrs::Dict
     writeable::Bool
 end
@@ -45,14 +46,20 @@ function Base.show(io::IO,::MIME"text/plain",z::ZArray)
     print(io, "ZArray{", eltype(z) ,"} of size ",join(string.(size(z)), " x "))
 end
 
-zname(z::ZArray) = zname(z.storage)
+zname(z::ZArray) = zname(z.path)
+
+function zname(s::String)
+  spl = split(rstrip(s,'/'),'/')
+  isempty(last(spl)) ? "root" : last(spl)
+end
+
 
 """
     storagesize(z::ZArray)
 
 Returns the size of the compressed data stored in the ZArray `z` in bytes
 """
-storagesize(z::ZArray) = storagesize(z.storage)
+storagesize(z::ZArray) = storagesize(z.storage,z.path)
 
 """
     storageratio(z::ZArray)
@@ -69,7 +76,7 @@ nobytes(z::ZArray{<:Vector}) = "unknown"
 zinfo(z::ZArray) = zinfo(stdout,z)
 function zinfo(io::IO,z::ZArray)
   ninit = sum(chunkindices(z)) do i
-    isinitialized(z.storage,i)
+    isinitialized(z.storage,z.path,i)
   end
   allinfos = [
     "Type" => "ZArray",
@@ -91,13 +98,13 @@ function zinfo(io::IO,z::ZArray)
   end
 end
 
-function ZArray(s::T, mode="r") where T <: AbstractStore
+function ZArray(s::T, mode="r",path="") where T <: AbstractStore
   metadata = getmetadata(s)
   attrs    = getattrs(s)
   writeable = mode == "w"
-
+  startswith(path,"/") && error("Paths should never start with a leading '/'")
   ZArray{eltype(metadata), length(metadata.shape[]), typeof(metadata.compressor), T}(
-    metadata, s, attrs, writeable)
+    metadata, s, path, attrs, writeable)
 end
 
 
@@ -148,13 +155,13 @@ function readblock!(aout::AbstractArray{<:Any,N}, z::ZArray{<:Any, N}, r::Cartes
     inds    = CartesianIndices(map(boundint,r.indices,axes(curchunk)))
 
     # Uncompress current chunk
-    if !readmode && !(isinitialized(z.storage, bI) && (size(inds) != size(a)))
+    if !readmode && !(isinitialized(z.storage, z.path, bI) && (size(inds) != size(a)))
       resetbuffer!(a)
     else
       readchunk!(maybeinner(a), z, bI)
     end
     if readmode
-      # Read data
+      # Read data 
       copyto!(aout,inds,curchunk,inds)
     else
       copyto!(curchunk,inds,aout,inds)
@@ -176,7 +183,7 @@ Read the chunk specified by `i` from the Zarray `z` and write its content to `a`
 """
 function readchunk!(a::DenseArray,z::ZArray{<:Any,N},i::CartesianIndex{N}) where N
     length(a) == prod(z.metadata.chunks) || throw(DimensionMismatch("Array size does not equal chunk size"))
-    curchunk = z.storage[i]
+    curchunk = z.storage[z.path,i]
     if curchunk === nothing
         fill!(a, z.metadata.fill_value)
     else
@@ -200,9 +207,9 @@ function writechunk!(a::DenseArray, z::ZArray{<:Any,N}, i::CartesianIndex{N}) wh
   if !allmissing(z,a)
     dtemp = UInt8[]
     zcompress!(dtemp,a,z.metadata.compressor, z.metadata.filters)
-    z.storage[i]=dtemp
+    z.storage[z.path,i]=dtemp
   else
-    isinitialized(z.storage,i) && delete!(z.storage,i)
+    isinitialized(z.storage,z.path,i) && delete!(z.storage,z.path,i)
   end
   a
 end
@@ -227,7 +234,7 @@ function zcreate(::Type{T}, dims...;
         kwargs...
         ) where T
   if path===nothing
-    store = DictStore("")
+    store = DictStore()
   else
     store = DirectoryStore(joinpath(path,name))
   end
@@ -236,6 +243,7 @@ end
 
 function zcreate(::Type{T},storage::AbstractStore,
         dims...;
+        path = "",
         chunks=dims,
         fill_value=nothing,
         compressor=BloscCompressor(),
@@ -259,14 +267,14 @@ function zcreate(::Type{T},storage::AbstractStore,
         filters,
     )
 
-    isempty(storage) || error("$storage is not empty")
+    isemptysub(storage,path) || error("$storage is not empty")
 
-    writemetadata(storage, metadata)
+    writemetadata(storage, path, metadata)
 
-    writeattrs(storage, attrs)
+    writeattrs(storage, path, attrs)
 
-    z = ZArray{T2, N, typeof(compressor), typeof(storage)}(
-        metadata, storage, attrs, writeable)
+    ZArray{T2, N, typeof(compressor), typeof(storage)}(
+        metadata, storage, path, attrs, writeable)
 end
 
 filterfromtype(::Type{<:Any}) = nothing

--- a/src/ZArray.jl
+++ b/src/ZArray.jl
@@ -267,7 +267,7 @@ function zcreate(::Type{T},storage::AbstractStore,
         filters,
     )
 
-    isemptysub(storage,path) || error("$storage is not empty")
+    isemptysub(storage,path) || error("$storage $path is not empty")
 
     writemetadata(storage, path, metadata)
 

--- a/src/ZGroup.jl
+++ b/src/ZGroup.jl
@@ -89,7 +89,7 @@ end
 Open a zarr Array or group at disc path p.
 """
 function zopen(s::String, mode="r"; kwargs...)
-  store, path = storefromstring(s)
+  store, path = storefromstring(s,false)
   zopen(store, mode; path=path, kwargs...)
 end
 

--- a/src/ZGroup.jl
+++ b/src/ZGroup.jl
@@ -47,7 +47,7 @@ function zopen_noerr(s::AbstractStore, mode="r"; consolidated = false, path="")
 end
 
 function Base.show(io::IO, g::ZGroup)
-    print(io, "ZarrGroup at ", g.storage)
+    print(io, "ZarrGroup at ", g.storage, " and path ", g.path)
     !isempty(g.arrays) && print(io, "\nVariables: ", map(i -> string(zname(i), " "), values(g.arrays))...)
     !isempty(g.groups) && print(io, "\nGroups: ", map(i -> string(zname(i), " "), values(g.groups))...)
     nothing
@@ -116,7 +116,7 @@ function zgroup(s::AbstractStore, path::String=""; attrs=Dict())
     isemptysub(s, path) || error("Store is not empty")
     b = IOBuffer()
     JSON.print(b,d)
-    s[".zgroup"]=take!(b)
+    s[path,".zgroup"]=take!(b)
     writeattrs(s,path,attrs)
     ZGroup(s, path, Dict{String,ZArray}(), Dict{String,ZGroup}(), attrs,true)
 end
@@ -126,7 +126,7 @@ zgroup(s::String;kwargs...)=zgroup(storefromstring(s, true)...;kwargs...)
 "Create a subgroup of the group g"
 function zgroup(g::ZGroup, name; attrs=Dict()) 
   g.writeable || throw(IOError("Zarr group is not writeable. Please re-open in write mode to create an array"))
-  g.groups[name] = zgroup(g.storage,attrs=attrs,path=_concatpath(g.path,name))
+  g.groups[name] = zgroup(g.storage,_concatpath(g.path,name),attrs=attrs)
 end
 
 "Create a new subarray of the group g"

--- a/src/ZGroup.jl
+++ b/src/ZGroup.jl
@@ -15,8 +15,8 @@ function ZGroup(s::T,mode="r",path="") where T <: AbstractStore
   groups = Dict{String, ZGroup}()
 
   for d in subdirs(s,path)
-    dshort = splitpath(d)[end]
-    m = zopen_noerr(s,mode,path=joinpath(path,dshort))
+    dshort = split(d,'/')[end]
+    m = zopen_noerr(s,mode,path=_concatpath(path,dshort))
     if isa(m, ZArray)
       arrays[dshort] = m
     elseif isa(m, ZGroup)

--- a/src/metadata.jl
+++ b/src/metadata.jl
@@ -23,12 +23,15 @@ Base.zero(::Union{ASCIIChar,Type{ASCIIChar}}) = ASCIIChar(Base.zero(UInt8))
 
 
 using Dates: Period, TimeType, Date, DateTime, Dates
+import Base.==
 struct DateTime64{P} <: TimeType
     i::Int64
 end
 Base.convert(::Type{Date},t::DateTime64{P}) where P = Date(1970)+P(t.i)
 Base.convert(::Type{DateTime},t::DateTime64{P}) where P = DateTime(1970)+P(t.i)
 Base.show(io::IO,t::DateTime64{P}) where P = print(io,"DateTime64[",P,"]: ",string(DateTime(t)))
+Base.isless(x::DateTime64{P}, y::DateTime64{P}) where P = isless(x.i, y.i)
+==(x::DateTime64{P}, y::DateTime64{P}) where P = x.i == y.i
 strpairs = [Dates.Year => "Y", Dates.Month => "M", Dates.Week => "W", Dates.Day=>"D", 
     Dates.Hour => "h", Dates.Minute => "m", Dates.Second=>"s", Dates.Millisecond =>"ms",
     Dates.Microsecond => "us", Dates.Nanosecond => "ns"]

--- a/test/python.jl
+++ b/test/python.jl
@@ -108,7 +108,7 @@ rm(joinpath(ppython,".zattrs"))
 rm(joinpath(ppython,"a1",".zattrs"))
 rm(joinpath(ppython,"a1",".zarray"))
 rm(joinpath(ppython,"a2",".zarray"))
-g = zopen(ppython, consolidated=true)
+g = zopen(ppython, "w", consolidated=true)
 @test g isa Zarr.ZGroup
 @test g.attrs["groupatt"] == "Hi"
 a1 = g["a1"]

--- a/test/python.jl
+++ b/test/python.jl
@@ -103,7 +103,7 @@ a1 = g["a1"]
 @test String(g["a2"][:])=="hallo"
 
 # And test for consolidated metadata
-# Delete files so we make sure they are note accessed
+# Delete files so we make sure they are not accessed
 rm(joinpath(ppython,".zattrs"))
 rm(joinpath(ppython,"a1",".zattrs"))
 rm(joinpath(ppython,"a1",".zarray"))
@@ -115,6 +115,10 @@ a1 = g["a1"]
 @test a1 isa ZArray
 @test a1[:,:,:]==permutedims(data,(3,2,1))
 @test a1.attrs["test"]==Dict("b"=>6)
+@test storagesize(a1) == 960
+@test sort(Zarr.subkeys(a1.storage,"a1"))[1:5] == [".zarray",".zattrs","0.0.0","0.0.1","0.0.2"]
+a1[:,1,1] = 1:10
+@test a1[:,1,1] == 1:10
 # Test reading the string array
 @test String(g["a2"][:])=="hallo"
 end

--- a/test/python.jl
+++ b/test/python.jl
@@ -116,7 +116,7 @@ a1 = g["a1"]
 @test a1[:,:,:]==permutedims(data,(3,2,1))
 @test a1.attrs["test"]==Dict("b"=>6)
 @test storagesize(a1) == 960
-@test sort(Zarr.subkeys(a1.storage,"a1"))[1:5] == [".zarray",".zattrs","0.0.0","0.0.1","0.0.2"]
+@test sort(Zarr.subkeys(a1.storage,"a1"))[1:5] == ["0.0.0","0.0.1","0.0.2","0.0.3","0.1.0"]
 a1[:,1,1] = 1:10
 @test a1[:,1,1] == 1:10
 # Test reading the string array

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -80,6 +80,17 @@ end
     end
 end
 
+@testset "Groups" begin
+    store = DirectoryStore(tempname())
+    g = zgroup(store,"mygroup")
+    g2 = zgroup(g,"asubgroup",attrs = Dict("a1"=>5))
+    @test Zarr.is_zgroup(store,"mygroup")
+    @test Zarr.is_zgroup(store,"mygroup/asubgroup")
+    @test g2.attrs["a1"]==5
+    @test isdir(joinpath(store.folder,"mygroup"))
+    @test isdir(joinpath(store.folder,"mygroup","asubgroup"))
+end
+
 @testset "Metadata" begin
     @testset "Data type encoding" begin
         @test Zarr.typestr(Bool) === "<b1"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,7 +20,6 @@ end
         @test z isa ZArray{Int64, 2, Zarr.BloscCompressor,
             Zarr.DictStore}
 
-        @test z.storage.name === "data"
         @test length(z.storage.a) === 3
         @test length(z.storage.a["0.0"]) === 64
         @test eltype(z.storage.a["0.0"]) === UInt8
@@ -48,7 +47,7 @@ end
         @test size(z, 2) === 3
         @test length(z) === 2 * 3
         @test lastindex(z, 2) === 3
-        @test Zarr.zname(z) === "data"
+        @test Zarr.zname(z) === "root"
     end
 
     @testset "NoCompressor DirectoryStore" begin

--- a/test/storage.jl
+++ b/test/storage.jl
@@ -12,36 +12,36 @@ end
 Function to test the interface of AbstractStore. Every complete implementation should pass this test.
 """
 function test_store_common(ds)
-  @test !Zarr.is_zgroup(ds)
+  @test !Zarr.is_zgroup(ds,"")
   ds[".zgroup"]=rand(UInt8,50)
   @test haskey(ds,".zgroup")
-  @test Zarr.is_zgroup(ds)
-  @test !Zarr.is_zarray(ds)
 
-  @test Zarr.zname(ds)=="foo"
-  @test isempty(Zarr.subdirs(ds))
-  @test sort(collect(Zarr.keys(ds)))==[".zgroup"]
+  @test Zarr.is_zgroup(ds,"")
+  @test !Zarr.is_zarray(ds,"")
+
+  @test isempty(Zarr.subdirs(ds,""))
+  @test sort(collect(Zarr.subkeys(ds,"")))==[".zgroup"]
 
   #Create a subgroup
-  snew = Zarr.newsub(ds,"bar")
-  @test !Zarr.is_zarray(ds)
-  snew[".zarray"] = rand(UInt8,50)
-  @test Zarr.is_zgroup(ds)
+  @test !Zarr.is_zarray(ds,"bar")
+  ds["bar/.zarray"] = rand(UInt8,50)
+
+  @test Zarr.is_zarray(ds,"bar")
+  @test Zarr.subdirs(ds,"") == ["bar"]
+  @test Zarr.subdirs(ds,"bar") == String[]
   #Test getindex and setindex
   data = rand(UInt8,50)
-  snew["0.0.0"] = data
-  @test snew["0.0.0"]==data
-  @test Zarr.storagesize(snew)==50
-  @test Zarr.isinitialized(snew,"0.0.0")
-  @test !Zarr.isinitialized(snew,"0.0.1")
-  Zarr.writeattrs(snew,Dict("a"=>"b"))
-  @test Zarr.getattrs(snew)==Dict("a"=>"b")
-  snew2 = Zarr.getsub(ds,"bar")
-  @test Zarr.getattrs(snew2)==Dict("a"=>"b")
-  @test snew2["0.0.0"]==data
-  delete!(snew2,"0.0.0")
-  @test !Zarr.isinitialized(snew2,"0.0.0")
-  snew["0.0.0"] = data
+  ds["bar/0.0.0"] = data
+  @test ds["bar/0.0.0"]==data
+  @test Zarr.storagesize(ds,"bar")==50
+  @test Zarr.isinitialized(ds,"bar/0.0.0")
+  @test !Zarr.isinitialized(ds,"bar/0.0.1")
+  Zarr.writeattrs(ds,"bar",Dict("a"=>"b"))
+  @test Zarr.getattrs(ds,"bar")==Dict("a"=>"b")
+  delete!(ds,"bar/0.0.0")
+  @test !Zarr.isinitialized(ds,"bar",CartesianIndex((0,0,0)))
+  @test !Zarr.isinitialized(ds,"bar/0.0.0")
+  ds["bar/0.0.0"] = data
 end
 
 @testset "DirectoryStore" begin
@@ -57,20 +57,17 @@ end
   @test isdir(joinpath(p,"foo","bar"))
   @test isfile(joinpath(p,"foo","bar","0.0.0"))
   @test isfile(joinpath(p,"foo","bar",".zarray"))
-  @test Zarr.path(ds)==replace(joinpath(p,"foo"),"\\"=>"/")
 end
 
 @testset "DictStore" begin
   A = fill(1.0, 30, 20)
   chunks = (5,10)
   metadata = Zarr.Metadata(A, chunks; fill_value=-1.5)
-  ds = Zarr.DictStore("foo")
+  ds = Zarr.DictStore()
   test_store_common(ds)
-  @test ds.name == "foo"
   @test haskey(ds.a,".zgroup")
-  @test ds.subdirs["bar"].a[".zattrs"]==UInt8[0x7b, 0x22, 0x61, 0x22, 0x3a, 0x22, 0x62, 0x22, 0x7d]
-  @test sort(collect(keys(ds.subdirs["bar"].a)))==[".zarray", ".zattrs", "0.0.0"]
-  @test isempty(keys(ds.subdirs["bar"].subdirs))
+  @test ds.a["bar/.zattrs"]==UInt8[0x7b, 0x22, 0x61, 0x22, 0x3a, 0x22, 0x62, 0x22, 0x7d]
+  @test sort(collect(keys(ds.a)))==[".zgroup","bar/.zarray", "bar/.zattrs", "bar/0.0.0"]
 end
 
 @testset "Minio S3 storage" begin
@@ -83,32 +80,28 @@ end
   cfg = MinioConfig("http://localhost:9001")
   Zarr.AWS.global_aws_config(cfg)
   Zarr.S3.create_bucket("zarrdata")
-  ds = S3Store("zarrdata","foo")
+  ds = S3Store("zarrdata")
   test_store_common(ds)
   @test sprint(show, ds) == "S3 Object Storage"
   kill(s)
 end
 
 @testset "AWS S3 Storage" begin
-    Zarr.AWS.global_aws_config(Zarr.AWS.AWSConfig(creds=nothing, region="eu-west-2"))
-    S3 = Zarr.storefromstring("s3://zarr-demo/store/foo")
-    @test storagesize(S3) == 0
-    @test Zarr.zname(S3) == "foo"
-    @test Zarr.is_zgroup(S3) == true
-    S3group = zopen(S3)
-    @test Zarr.zname(S3group) == "foo"
-    S3Array = S3group.groups["bar"].arrays["baz"]
-    @test Zarr.zname(S3Array) == "baz"
-    @test eltype(S3Array) == Zarr.ASCIIChar
-    @test storagesize(S3Array) == 69
-    @test String(S3Array[:]) == "Hello from the cloud!"
+  Zarr.AWS.global_aws_config(Zarr.AWS.AWSConfig(creds=nothing, region="eu-west-2"))
+  S3,p = Zarr.storefromstring("s3://zarr-demo/store/foo")
+  @test storagesize(S3,p) == 0
+  @test Zarr.is_zgroup(S3,p) == true
+  S3group = zopen(S3,path=p)
+  S3Array = S3group.groups["bar"].arrays["baz"]
+  @test eltype(S3Array) == Zarr.ASCIIChar
+  @test storagesize(S3Array) == 69
+  @test String(S3Array[:]) == "Hello from the cloud!"
 end
 
 @testset "GCS S3 Storage" begin
-  cmip6 = Zarr.storefromstring("gs://cmip6/CMIP6/HighResMIP/CMCC/CMCC-CM2-HR4/highresSST-present/r1i1p1f1/6hrPlev/psl/gn/v20170706/")
-  @test storagesize(cmip6) == 16098
-  @test Zarr.zname(cmip6) == "v20170706"
-  g = zopen(cmip6)
+  cmip6,p = Zarr.storefromstring("gs://cmip6/CMIP6/HighResMIP/CMCC/CMCC-CM2-HR4/highresSST-present/r1i1p1f1/6hrPlev/psl/gn/v20170706/")
+  @test storagesize(cmip6,p) == 16098
+  g = zopen(cmip6,path=p)
   arr = g["psl"]
   @test size(arr) == (288, 192, 97820)
   @test eltype(arr) == Union{Missing, Float32}

--- a/test/storage.jl
+++ b/test/storage.jl
@@ -57,7 +57,6 @@ end
   @test isdir(joinpath(p,"foo","bar"))
   @test isfile(joinpath(p,"foo","bar","0.0.0"))
   @test isfile(joinpath(p,"foo","bar",".zarray"))
-  @test Zarr.path(ds)==replace(joinpath(p,"foo"),"\\"=>"/")
   #Test that error is thrown when path does not exist and no folder is created
   @test_throws ArgumentError zopen("thisfolderdoesnotexist")
   @test !isdir("thisfolderdoesnotexist")


### PR DESCRIPTION
In the past the interface for an `AbstractStore` was different to the one used in python and other Zarr implementations and led to more repetition in implementing subclasses of `AbstractStore`. To describe the difference, let's look at an example. In the previous implementation an `AbstractStore` could only point to a single Zarr Group or Array and contained the full path information in the type. When accessing a sub-array of a group, a new Store had to be created which pointed to this sub-path etc. In the new implementation a ZArray or ZGroup contains an `AbstractStore` as well as the base path inside that Storage, so that the same Storage object can be shared among different ZArrays or ZGroups in that same storage and are distinguished by their `path`s. 

This change allowed for more code sharing between different storage types, because the whole subsetting logic did not have to be re-implemented for different storages. However, it was a massive re-write and thing might initially be a bit less stable than before but I hope this will return to be more maintainable in the long run. 