### PR TITLE
[WIP] add GCStore using Google Cloud Storage REST API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LRUCache = "8ac3fa9e-de4c-5943-b1dc-09c6b5f20637"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 
 [compat]
 AWS = "1.25 - 1.61"
@@ -26,6 +27,7 @@ HTTP = "0.8, 0.9"
 JSON = "0.21"
 LRUCache = "1"
 OffsetArrays = "0.11, 1.0"
+URIs = "1"
 julia = "1.2"
 
 [extras]

--- a/src/Storage/Storage.jl
+++ b/src/Storage/Storage.jl
@@ -103,5 +103,6 @@ storageregexlist = Pair[]
 include("directorystore.jl")
 include("dictstore.jl")
 include("s3store.jl")
+include("gcstore.jl")
 include("consolidated.jl")
 include("http.jl")

--- a/src/Storage/gcstore.jl
+++ b/src/Storage/gcstore.jl
@@ -1,0 +1,148 @@
+using URIs: URI
+
+const GOOGLE_STORAGE_API = "https://storage.googleapis.com"
+const GOOGLE_STORAGE_REST_API = GOOGLE_STORAGE_API * "/storage/v1"
+const GOOGLE_STORAGE_CREDENTIALS = Dict{String,String}()
+
+"""
+    Zarr.gcs_credentials(user_project,access_token,token_type)
+
+Set the user project, access token and and token type for the Google Cloud
+Store.
+"""
+function gcs_credentials(user_project,access_token,token_type)
+  GOOGLE_STORAGE_CREDENTIALS["user_project"] = user_project
+  GOOGLE_STORAGE_CREDENTIALS["access_token"] = access_token
+  GOOGLE_STORAGE_CREDENTIALS["token_type"] = token_type
+  nothing
+end
+
+"""
+    Zarr.gcs_credentials(; metadata_url = "http://metadata.google.internal/computeMetadata/v1/")
+
+Set (or renew) the user project, access token and and token type for the Google
+Cloud Store from the Meatadata server (assuming the function is executed from
+the Google Cloud).
+For some data sets, the error message "Bucket is requester pays bucket but no
+user project provided" is returned if the credentials are not provided.
+"""
+function gcs_credentials(;metadata_url = "http://metadata.google.internal/computeMetadata/v1/")
+  headers = Dict("Metadata-Flavor" => "Google")
+
+  url = joinpath(metadata_url,"project","project-id")
+  user_project = String(HTTP.get(url, headers=headers).body)
+
+  url = joinpath(metadata_url,"instance","service-accounts","default","token")
+  auth = JSON.parse(String(HTTP.get(url,headers).body));
+
+  gcs_credentials(user_project,auth["access_token"],auth["token_type"])
+end
+
+
+function _gcs_request_headers()
+  headers = Dict{String,String}()
+  if haskey(GOOGLE_STORAGE_CREDENTIALS,"user_project")
+    headers["x-goog-user-project"] = GOOGLE_STORAGE_CREDENTIALS["user_project"]
+  end
+
+  if haskey(GOOGLE_STORAGE_CREDENTIALS,"token_type") &&
+    haskey(GOOGLE_STORAGE_CREDENTIALS,"access_token")
+
+    headers["Authorization"] = string(
+      GOOGLE_STORAGE_CREDENTIALS["token_type"]," ",
+      GOOGLE_STORAGE_CREDENTIALS["access_token"])
+  end
+
+  return headers
+end
+
+struct GCStore <: AbstractStore
+  bucket::String
+
+  function GCStore(url::String)
+    uri = URI(url)
+
+    if uri.scheme == "gs"
+      bucket = uri.host
+    else
+      parts = split(uri.path,'/',limit=3)
+      bucket = parts[2]
+    end
+    @debug "GCS bucket: $bucket"
+    new(bucket)
+  end
+end
+
+
+function Base.getindex(s::GCStore, k::String)
+  url = string(GOOGLE_STORAGE_API,"/",s.bucket,"/",k)
+  headers = _gcs_request_headers()
+  r = HTTP.request("GET",url,headers,status_exception = false)
+  if r.status >= 300
+    if r.status == 404
+      @debug "get: $url: not found"
+      nothing
+    else
+      error("Error connecting to $(s.url) :", String(r.body))
+    end
+  else
+    @debug "get: $url"
+    r.body
+  end
+end
+
+function cloud_list_objects(s::GCStore,p)
+  prefix = (isempty(p) || endswith(p,"/")) ? p : string(p,"/")
+
+  url = string(GOOGLE_STORAGE_REST_API, "/b/", s.bucket, "/o")
+
+  @debug "call: $url"
+  headers = _gcs_request_headers()
+  params = Dict("prefix" => prefix, "delimiter" => "/")
+  r = JSON.parse(String(HTTP.get(url,headers,
+                                 query = params).body))
+
+  return r
+end
+
+function storagesize(s::GCStore,p)
+  r = cloud_list_objects(s,p)
+  items = r["items"]
+  datafiles = filter(entry -> !any(filename -> endswith(entry["name"], filename), [".zattrs",".zarray",".zgroup"]), items)
+  if isempty(datafiles)
+    0
+  else
+    sum(datafiles) do f
+      parse(Int, f["size"])
+    end
+  end
+end
+
+function subkeys(s::GCStore, p)
+  r = cloud_list_objects(s, p)
+  keys = map(item -> String(split(item["name"],'/')[end]),  r["items"])
+  return keys
+end
+
+function subdirs(s::GCStore, p)
+  r = cloud_list_objects(s,p)
+  dirs = map(prefix -> String(split(prefix,'/')[end-1]), r["prefixes"])
+  return dirs
+end
+
+pushfirst!(storageregexlist,r"^https://storage.googleapis.com"=>GCStore)
+pushfirst!(storageregexlist,r"^http://storage.googleapis.com"=>GCStore)
+#push!(storageregexlist,r"^gs://"=>GCStore)
+
+function storefromstring(::Type{<:GCStore}, url,_)
+  uri = URI(url)
+  if uri.scheme == "gs"
+    p = lstrip(uri.path,'/')
+  else
+    parts = split(uri.path,'/',limit=2, keepempty=false)
+    p = (length(parts) == 2 ? parts[2] : "")
+  end
+
+  @debug "path: $p"
+  return GCStore(url),p
+end

--- a/src/ZGroup.jl
+++ b/src/ZGroup.jl
@@ -7,6 +7,10 @@ struct ZGroup{S<:AbstractStore}
     writeable::Bool
 end
 
+# path can also be a SubString{String}
+ZGroup(storage, path::AbstractString, arrays, groups, attrs, writeable) =
+    ZGroup(storage, String(path), arrays, groups, attrs, writeable)
+
 zname(g::ZGroup) = zname(g.path)
 
 #Open an existing ZGroup

--- a/src/Zarr.jl
+++ b/src/Zarr.jl
@@ -12,6 +12,6 @@ include("ZGroup.jl")
 include("Storage/lru.jl")
 
 export ZArray, ZGroup, zopen, zzeros, zcreate, storagesize, storageratio,
-  zinfo, DirectoryStore, S3Store, zgroup
+  zinfo, DirectoryStore, S3Store, GCStore, zgroup
 
 end # module

--- a/test/storage.jl
+++ b/test/storage.jl
@@ -124,17 +124,21 @@ end
   @test String(S3Array[:]) == "Hello from the cloud!"
 end
 
-@testset "GCS S3 Storage" begin
-  cmip6,p = Zarr.storefromstring("gs://cmip6/CMIP6/HighResMIP/CMCC/CMCC-CM2-HR4/highresSST-present/r1i1p1f1/6hrPlev/psl/gn/v20170706/")
-  @test storagesize(cmip6,p) == 16098
-  g = zopen(cmip6,path=p)
-  arr = g["psl"]
-  @test size(arr) == (288, 192, 97820)
-  @test eltype(arr) == Union{Missing, Float32}
-  lat = g["lat"]
-  @test size(lat) == (192,)
-  @test eltype(lat) == Union{Missing, Float64}
-  @test lat[1:4] == [-90.0,-89.05759162303664,-88.1151832460733,-87.17277486910994]
+@testset "GCS Storage" begin
+  for (cmip6,p) in (
+      Zarr.storefromstring("gs://cmip6/CMIP6/HighResMIP/CMCC/CMCC-CM2-HR4/highresSST-present/r1i1p1f1/6hrPlev/psl/gn/v20170706/"),
+      Zarr.storefromstring(GCStore,"gs://cmip6/CMIP6/HighResMIP/CMCC/CMCC-CM2-HR4/highresSST-present/r1i1p1f1/6hrPlev/psl/gn/v20170706/",false))
+
+    @test storagesize(cmip6,p) == 16098
+    g = zopen(cmip6,path=p)
+    arr = g["psl"]
+    @test size(arr) == (288, 192, 97820)
+    @test eltype(arr) == Union{Missing, Float32}
+    lat = g["lat"]
+    @test size(lat) == (192,)
+    @test eltype(lat) == Union{Missing, Float64}
+    @test lat[1:4] == [-90.0,-89.05759162303664,-88.1151832460733,-87.17277486910994]
+  end
 end
 
 @testset "HTTP Storage" begin


### PR DESCRIPTION
Here is the promised PR for issue https://github.com/meggart/Zarr.jl/issues/71 .

Note that it uses URIs an additional dependency ([URIs](https://github.com/JuliaWeb/URIs.jl/blob/master/Project.toml) is pure Julia with no dependencies itself). Let me know if this OK for you, otherwise I can update the PR so that it does not use URIs.

The PR also works with URLs starting with `gs://`:

```julia
store, path = Zarr.storefromstring(GCStore,"gs://cmip6/CMIP6/CMIP/AS-RCEC/TaiESM1/1pctCO2/r1i1p1f1/Amon/hfls/gn/v20200225/",false)
zds = zopen(store,path=path)
```
But  `AnonymousGCS` is still the default for such URLs.

I can also contribute some additional information to the documentation.