### PR TITLE
Remove AnonymousGCS

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Zarr"
 uuid = "0a941bbe-ad1d-11e8-39d9-ab76183a1d99"
 authors = ["Fabian Gans <fgans@bgc-jena.mpg.de>"]
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 AWS = "fbe9abb3-538b-5e4e-ba9e-bc94f4f92ebc"

--- a/src/Storage/gcstore.jl
+++ b/src/Storage/gcstore.jl
@@ -132,7 +132,7 @@ end
 
 pushfirst!(storageregexlist,r"^https://storage.googleapis.com"=>GCStore)
 pushfirst!(storageregexlist,r"^http://storage.googleapis.com"=>GCStore)
-#push!(storageregexlist,r"^gs://"=>GCStore)
+push!(storageregexlist,r"^gs://"=>GCStore)
 
 function storefromstring(::Type{<:GCStore}, url,_)
   uri = URI(url)

--- a/test/storage.jl
+++ b/test/storage.jl
@@ -125,9 +125,9 @@ end
 end
 
 @testset "GCS Storage" begin
-  cmip6,p = Zarr.storefromstring("gs://cmip6/CMIP6/HighResMIP/CMCC/CMCC-CM2-HR4/highresSST-present/r1i1p1f1/6hrPlev/psl/gn/v20170706/"),
+  cmip6,p = Zarr.storefromstring("gs://cmip6/CMIP6/HighResMIP/CMCC/CMCC-CM2-HR4/highresSST-present/r1i1p1f1/6hrPlev/psl/gn/v20170706")
   @test cmip6 isa Zarr.GCStore
-  @test p == "CMIP6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp370/r3i1p1f1/Amon/tas/gn/v20190710"
+  @test p == "CMIP6/HighResMIP/CMCC/CMCC-CM2-HR4/highresSST-present/r1i1p1f1/6hrPlev/psl/gn/v20170706"
   @test storagesize(cmip6,p) == 16098
   g = zopen(cmip6,path=p)
   arr = g["psl"]

--- a/test/storage.jl
+++ b/test/storage.jl
@@ -125,18 +125,24 @@ end
 end
 
 @testset "GCS Storage" begin
-  cmip6,p = Zarr.storefromstring("gs://cmip6/CMIP6/HighResMIP/CMCC/CMCC-CM2-HR4/highresSST-present/r1i1p1f1/6hrPlev/psl/gn/v20170706")
-  @test cmip6 isa Zarr.GCStore
-  @test p == "CMIP6/HighResMIP/CMCC/CMCC-CM2-HR4/highresSST-present/r1i1p1f1/6hrPlev/psl/gn/v20170706"
-  @test storagesize(cmip6,p) == 16098
-  g = zopen(cmip6,path=p)
-  arr = g["psl"]
-  @test size(arr) == (288, 192, 97820)
-  @test eltype(arr) == Union{Missing, Float32}
-  lat = g["lat"]
-  @test size(lat) == (192,)
-  @test eltype(lat) == Union{Missing, Float64}
-  @test lat[1:4] == [-90.0,-89.05759162303664,-88.1151832460733,-87.17277486910994]
+  for s in (
+    "gs://cmip6/CMIP6/HighResMIP/CMCC/CMCC-CM2-HR4/highresSST-present/r1i1p1f1/6hrPlev/psl/gn/v20170706",
+    "https://storage.googleapis.com/cmip6/CMIP6/HighResMIP/CMCC/CMCC-CM2-HR4/highresSST-present/r1i1p1f1/6hrPlev/psl/gn/v20170706",
+    "http://storage.googleapis.com/cmip6/CMIP6/HighResMIP/CMCC/CMCC-CM2-HR4/highresSST-present/r1i1p1f1/6hrPlev/psl/gn/v20170706",
+  )
+    cmip6,p = Zarr.storefromstring(s)
+    @test cmip6 isa Zarr.GCStore
+    @test p == "CMIP6/HighResMIP/CMCC/CMCC-CM2-HR4/highresSST-present/r1i1p1f1/6hrPlev/psl/gn/v20170706"
+    @test storagesize(cmip6,p) == 16098
+    g = zopen(cmip6,path=p)
+    arr = g["psl"]
+    @test size(arr) == (288, 192, 97820)
+    @test eltype(arr) == Union{Missing, Float32}
+    lat = g["lat"]
+    @test size(lat) == (192,)
+    @test eltype(lat) == Union{Missing, Float64}
+    @test lat[1:4] == [-90.0,-89.05759162303664,-88.1151832460733,-87.17277486910994]
+  end
 end
 
 @testset "HTTP Storage" begin

--- a/test/storage.jl
+++ b/test/storage.jl
@@ -125,20 +125,18 @@ end
 end
 
 @testset "GCS Storage" begin
-  for (cmip6,p) in (
-      Zarr.storefromstring("gs://cmip6/CMIP6/HighResMIP/CMCC/CMCC-CM2-HR4/highresSST-present/r1i1p1f1/6hrPlev/psl/gn/v20170706/"),
-      Zarr.storefromstring(GCStore,"gs://cmip6/CMIP6/HighResMIP/CMCC/CMCC-CM2-HR4/highresSST-present/r1i1p1f1/6hrPlev/psl/gn/v20170706/",false))
-
-    @test storagesize(cmip6,p) == 16098
-    g = zopen(cmip6,path=p)
-    arr = g["psl"]
-    @test size(arr) == (288, 192, 97820)
-    @test eltype(arr) == Union{Missing, Float32}
-    lat = g["lat"]
-    @test size(lat) == (192,)
-    @test eltype(lat) == Union{Missing, Float64}
-    @test lat[1:4] == [-90.0,-89.05759162303664,-88.1151832460733,-87.17277486910994]
-  end
+  cmip6,p = Zarr.storefromstring("gs://cmip6/CMIP6/HighResMIP/CMCC/CMCC-CM2-HR4/highresSST-present/r1i1p1f1/6hrPlev/psl/gn/v20170706/"),
+  @test cmip6 isa Zarr.GCStore
+  @test p == "CMIP6/ScenarioMIP/DKRZ/MPI-ESM1-2-HR/ssp370/r3i1p1f1/Amon/tas/gn/v20190710"
+  @test storagesize(cmip6,p) == 16098
+  g = zopen(cmip6,path=p)
+  arr = g["psl"]
+  @test size(arr) == (288, 192, 97820)
+  @test eltype(arr) == Union{Missing, Float32}
+  lat = g["lat"]
+  @test size(lat) == (192,)
+  @test eltype(lat) == Union{Missing, Float64}
+  @test lat[1:4] == [-90.0,-89.05759162303664,-88.1151832460733,-87.17277486910994]
 end
 
 @testset "HTTP Storage" begin


### PR DESCRIPTION
This makes the new `GCStore` implemented by @Alexander-Barth the default for opening strings starting with "gs://" and removes the old `AnonymousGCS` implementation entirely, which was currently causing a bug in the unit tests anyway. 

Thanks again @Alexander-Barth  